### PR TITLE
Cover image ratio optimization

### DIFF
--- a/src/components/Book.js
+++ b/src/components/Book.js
@@ -3,7 +3,7 @@ import { mapActions } from 'vuex'
 
 export default {
     template: `<div class="book" draggable="true" @dragend="dragEnd" @dragstart="dragStart(bookId, listId)">
-                    <img :src="bookImagePath" :title="bookName" @click="openBook(bookPath)" />
+                    <img :src="bookImagePath" :title="bookName" @click="openBook(bookPath)" style="object-fit:contain;" />
                     <button title="Remove Book" class="remove-book-btn dred" 
                         @click="removeBook({bookId: bookId,
                                             bookAuthor: bookAuthor,


### PR DESCRIPTION
The original code stretches the cover image of books to fill the frame, which looks not good when the cover image has a longer width

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/37651510/95450333-b3bb2f00-0998-11eb-83b7-60abf088765c.png">

So I add extra CSS code to make it adjust its ratio and it looks better
<img width="637" alt="image" src="https://user-images.githubusercontent.com/37651510/95450668-317f3a80-0999-11eb-92e7-b3168afe9c62.png">
